### PR TITLE
Don't zoom out upon loading features

### DIFF
--- a/wfsclientdialog.py
+++ b/wfsclientdialog.py
@@ -918,7 +918,6 @@ class WfsClientDialog(QtGui.QDialog):
                             hasfeatures = True
                             QgsMapLayerRegistry.instance().addMapLayers([vlayer])
                             logging.debug("... added Layer! QgsFeatureCount: " + str(featurecount))
-                            self.parent.iface.mapCanvas().zoomToFullExtent()
 
 
             if hasfeatures == False:


### PR DESCRIPTION
Previously upon loading new WFS features, the plugin
forced QGIS to zoom out to the extent of the widest layer
on the canvas.

This patch removes that behavior: the zoom will not change
automatically.

Reasons I find this preferrable:

- Adding a new layer from another source (shapefile, raster,
  SpatiaLite) does not zoom.
- If I am already zoomed into an area of interest, don't
  undo that.
- At first I found the zoom confusing: I thought it implied
  something about the WFS results (it does not: it zooms to
  the widest layer, even if that layer has nothing to do with
  WFS).